### PR TITLE
Use render to get the rendered CSS.

### DIFF
--- a/main.js
+++ b/main.js
@@ -27,10 +27,18 @@
       if (!Style || Style._injected) { return; }
       Style._injected = true;
       var name = getStyleComponentName(this);
-      var css = Style.create().renderToBuffer().buffer;
+      var css = getCSSFromComponent(Style);
       inject(name, css);
     }.on('willInsertElement')
   });
+
+  function getCSSFromComponent(component) {
+    var instance = component.create();
+    var buffer = new Ember.RenderBuffer();
+
+    instance.render(buffer)
+    return buffer.string();
+  }
 
   function getStyleComponentName(component) {
     var tagName = component.get('tagName');

--- a/testem.json
+++ b/testem.json
@@ -2,7 +2,7 @@
   "framework": "qunit",
   "src_files": [
     "bower_components/sinon/index.js",
-    "bower_components/jquery/jquery.js",
+    "bower_components/jquery/dist/jquery.js",
     "bower_components/handlebars/handlebars.js",
     "bower_components/ember/ember.js",
     "main.js",


### PR DESCRIPTION
`Ember.View.prototype.renderToBuffer` was private API and is removed on current master.

This swaps to using all public API surface, and works properly on all three Ember channels (stable, beta, and canary).  It should work all the way back to 1.0 (though I didn't test that far).
